### PR TITLE
Fix parsing of formating codes

### DIFF
--- a/lib/Pod/AsciiDoctor.pm
+++ b/lib/Pod/AsciiDoctor.pm
@@ -147,7 +147,23 @@ sub textblock {
     my $self = shift;
     my ($paragraph, $lineno) = @_;
     chomp($paragraph);
+    $paragraph = $self->interpolate($paragraph);
     $self->append($paragraph);
+}
+
+=head2 interior_sequence
+
+    Overrides Pod::Parser::interior_sequence (Copied from the Pod::Parser)
+
+=cut
+
+sub interior_sequence { 
+    my ($parser, $seq_command, $seq_argument) = @_;
+    ## Expand an interior sequence; sample actions might be:
+    print "Called\n";
+    return "*$seq_argument*"     if ($seq_command eq 'B');
+    return "`$seq_argument`"     if ($seq_command eq 'C');
+    return "_${seq_argument}_'"  if ($seq_command eq 'I');
 }
 
 =head2 make_header

--- a/t/01-conversion.t
+++ b/t/01-conversion.t
@@ -1,0 +1,16 @@
+#!perl -T
+
+use 5.006;
+# use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use Pod::AsciiDoctor;
+
+
+
+my $adoc = Pod::AsciiDoctor->new();
+$adoc->parse_from_file("t/data/pod.pm");
+
+ok($adoc->adoc() =~ /`\$x >> 3` or even `\$y >> 5`/, "Converted C<<< \$x >> 3 >>> or even C<<<< \$y >> 5 >>>>.");
+
+done_testing();

--- a/t/data/pod.pm
+++ b/t/data/pod.pm
@@ -1,0 +1,30 @@
+=pod
+
+This is a test to see if I can do not only C<$self> and C<method()>, but
+also C<< $self->method() >> and C<< $self->{FIELDNAME} >> and
+C<< $Foo <=> $Bar >> without resorting to escape sequences. If 
+I want to refer to the right-shift operator I can do something
+like C<<< $x >> 3 >>> or even C<<<< $y >> 5 >>>>.
+
+Now for the grand finale of C<< $self->method()->{FIELDNAME} = {FOO=>BAR} >>.
+And I also want to make sure that newlines work like this
+C<<<
+$self->{FOOBAR} >> 3 and [$b => $a]->[$a <=> $b]
+>>>
+
+Of course I should still be able to do all this I<with> escape sequences
+too: C<$self-E<gt>method()> and C<$self-E<gt>{FIELDNAME}> and C<{FOO=E<gt>BAR}>.
+
+Dont forget C<$self-E<gt>method()-E<gt>{FIELDNAME} = {FOO=E<gt>BAR}>.
+
+And make sure that C<0> works too!
+
+Now, if I use << or >> as my delimiters, then I have to use whitespace.
+So things like C<<$self->method()>> and C<<$self->{FIELDNAME}>> wont end
+up doing what you might expect since the first > will still terminate
+the first < seen.
+
+Lets make sure these work for empty ones too, like C<<  >> and C<< >> >>
+(just to be obnoxious)
+
+=cut


### PR DESCRIPTION
This fixes the formatting codes that were not being parsed correctly, as
described in the bug opended on github.

A test has been added too to ensure correctness.

https://github.com/benignbala/pod-asciidoctor/issues/3